### PR TITLE
check platform system before running WindowsSelectorEventLoopPolicy

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 import random
 import os
+from platform import system
 from datetime import datetime
 from factory import PackageFactory
 
@@ -60,5 +61,6 @@ def run_benchmarks():
             print("-" * 40)
 
 if __name__ == "__main__":
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    if system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     run_benchmarks()


### PR DESCRIPTION
I tried running benchmark.py on my Mac and I got:
```python
Traceback (most recent call last):
  File "python-http-libraries-benchmark/benchmark.py", line 63, in <module>
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'asyncio' has no attribute 'WindowsSelectorEventLoopPolicy'
```

Looking online, that attribute is available only on Windows Systems.