### PR TITLE
Add aiohttp speedups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp
+aiohttp[speedups]
 httpx
 requests
 urllib3


### PR DESCRIPTION
If we're benchmarking, then we should really include the optional speedups packages too.
If users want the fastest option, then they'll likely be installing these.