### PR TITLE
feat: add CI workflow and headless/configurable benchmark support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,56 @@
+name: Benchmark
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight UTC
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: 'Python version (e.g. 3.11, 3.12, 3.13)'
+        required: false
+        default: '3.12'
+      num_runs:
+        description: 'Number of benchmark runs'
+        required: false
+        default: '21'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version || '3.12' }}
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libcurl4-openssl-dev libssl-dev
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Start local HTTP server
+        run: python -m http.server 8080 &
+
+      - name: Wait for server
+        run: sleep 2
+
+      - name: Run benchmarks
+        env:
+          BENCHMARK_URL: http://localhost:8080
+          BENCHMARK_RUNS: ${{ inputs.num_runs || '21' }}
+        run: python benchmark.py
+
+      - name: Generate charts
+        run: python benchmark_analytics.py
+
+      - name: Commit results
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benchmark_results.csv *.png
+          git diff --staged --quiet || git commit -m "chore: update benchmark results [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ These metrics are chosen to reflect practical usage in applications such as REST
 
 To ensure fair and unbiased comparisons:
 
-- Each run sends a fixed number of requests (`NUM_REQUESTS = 100`) to `https://postman-echo.com/get`.
-- The script performs **6 complete benchmark runs**, where the first is used as warm-up and excluded from the CSV output.
+- Each run sends a fixed number of requests (`NUM_REQUESTS = 100`) to a local HTTP server (`http://localhost` by default).
+- The script performs **101 complete benchmark runs**, where the first is used as warm-up and excluded from the CSV output.
 - **Randomized Execution Order**: For every run, the order in which HTTP libraries are tested is randomized. This prevents any one library from benefiting from system or network caching effects due to consistent positioning.
 
 ---
@@ -54,14 +54,42 @@ Benchmark results are stored in `benchmark_results.csv`. Each row represents one
 ```bash
 pip install -r requirements.txt
 ```
-2. **Running the benchmark:**
+
+2. **Start a local HTTP server** (in a separate terminal):
+
 ```bash
-python benchmark.py
+python -m http.server 8080
 ```
-3. **Running Analytics:**
+
+3. **Run the benchmark:**
+
+```bash
+BENCHMARK_URL=http://localhost:8080 python benchmark.py
+```
+
+4. **Generate charts:**
+
 ```bash
 python benchmark_analytics.py
 ```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `BENCHMARK_URL` | `http://localhost` | Target URL for requests |
+| `BENCHMARK_RUNS` | `101` | Total number of runs (first is warm-up) |
+
+Example with custom values:
+```bash
+BENCHMARK_URL=http://localhost:8080 BENCHMARK_RUNS=11 python benchmark.py
+```
+
+---
+
+## ⚙️ CI
+
+A GitHub Actions workflow runs the benchmark automatically every Sunday and commits updated results and charts back to the repository. It can also be triggered manually via the **Actions** tab, with optional inputs for Python version and number of runs.
 
 ## Results
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -44,7 +44,8 @@ def run_benchmarks():
         if not file_exists:
             writer.writeheader()
 
-        for run in range(101):
+        num_runs = int(os.environ.get("BENCHMARK_RUNS", 101))
+        for run in range(num_runs):
             print(f"Benchmark run: {run + 1}")
             random.shuffle(packages)
 

--- a/benchmark_analytics.py
+++ b/benchmark_analytics.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use("Agg")
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -34,7 +36,7 @@ def plot_metric(metric_key, title, ylabel, filename):
     plt.grid(True)
     plt.tight_layout()
     plt.savefig(filename)
-    plt.show()
+    plt.close()
 
 
 # Generate all plots

--- a/factory.py
+++ b/factory.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import time
 import requests
 import httpx
@@ -8,7 +9,7 @@ import pycurl
 from io import BytesIO
 from model import BenchmarkResult
 
-TEST_URL = "http://localhost"
+TEST_URL = os.environ.get("BENCHMARK_URL", "http://localhost")
 NUM_REQUESTS_PER_PACKAGE_RUN = 100
 CONCURRENT_REQUESTS = 1
 


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs benchmarks on a schedule (weekly) and on-demand via `workflow_dispatch`
- Makes `TEST_URL` and run count configurable via env vars (`BENCHMARK_URL`, `BENCHMARK_RUNS`)
- Fixes matplotlib headless rendering for CI environments
- Commits updated CSV results and PNG charts back to the repo after each run

## Changes
- `.github/workflows/benchmark.yml` — new workflow (scheduled + manual, spins up local HTTP server on port 8080)
- `factory.py` — `TEST_URL` reads from `BENCHMARK_URL` env var, falls back to `http://localhost`
- `benchmark.py` — run count reads from `BENCHMARK_RUNS` env var, falls back to `101`
- `benchmark_analytics.py` — forces `Agg` backend, replaced `plt.show()` with `plt.close()`

## Test plan
- [x] Run locally: `BENCHMARK_URL=http://localhost:8080 BENCHMARK_RUNS=5 python3 benchmark.py`
- [x] Confirm CSV written and PNGs generated
- [x] Trigger workflow manually via GitHub Actions tab with custom Python version and run count

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)