### PR TITLE
fix: grant contents:write permission to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
`GITHUB_TOKEN` defaults to read-only — the `git push` in the commit step fails with 403. Adds `permissions: contents: write` to the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)