### PR TITLE
chore: bump actions/checkout and actions/setup-python to v6

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,10 +21,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python_version || '3.12' }}
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` and `actions/setup-python` from v4/v5 to v6
- Resolves Node.js 20 deprecation warning — v6 runs on Node.js 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)